### PR TITLE
Remove output device from LEDOutput

### DIFF
--- a/audioled/configs.py
+++ b/audioled/configs.py
@@ -8,13 +8,13 @@ from audioled import effects
 from audioled import input
 
 
-def createMovingLightGraph(N_pixels, device):
+def createMovingLightGraph(N_pixels):
     fg = filtergraph.FilterGraph(recordTimings=True)
 
     audio_in = audio.AudioInput(num_channels=2)
     fg.addEffectNode(audio_in)
 
-    led_out = devices.LEDOutput(device)
+    led_out = devices.LEDOutput()
     fg.addEffectNode(led_out)
 
     N_pixels = int(N_pixels / 2)
@@ -43,13 +43,13 @@ def createMovingLightGraph(N_pixels, device):
     return fg
 
 
-def createMovingLightsGraph(N_pixels, device):
+def createMovingLightsGraph(N_pixels):
     fg = filtergraph.FilterGraph(recordTimings=True)
 
     audio_in = audio.AudioInput(num_channels=2)
     fg.addEffectNode(audio_in)
 
-    led_out = devices.LEDOutput(device)
+    led_out = devices.LEDOutput()
     fg.addEffectNode(led_out)
 
     N_pixels = int(N_pixels / 2)
@@ -105,13 +105,13 @@ def createMovingLightsGraph(N_pixels, device):
     return fg
 
 
-def createSpectrumGraph(N_pixels, device):
+def createSpectrumGraph(N_pixels):
     fg = filtergraph.FilterGraph(recordTimings=True)
 
     audio_in = audio.AudioInput(num_channels=2)
     fg.addEffectNode(audio_in)
 
-    led_out = devices.LEDOutput(device)
+    led_out = devices.LEDOutput()
     fg.addEffectNode(led_out)
 
     N_pixels = int(N_pixels / 2)
@@ -141,14 +141,14 @@ def createSpectrumGraph(N_pixels, device):
     return fg
 
 
-def createVUPeakGraph(N_pixels, device):
+def createVUPeakGraph(N_pixels):
 
     fg = filtergraph.FilterGraph(recordTimings=True)
 
     audio_in = audio.AudioInput(num_channels=2)
     fg.addEffectNode(audio_in)
 
-    led_out = devices.LEDOutput(device)
+    led_out = devices.LEDOutput()
     fg.addEffectNode(led_out)
 
     N_pixels = int(N_pixels / 2)
@@ -188,11 +188,11 @@ def createVUPeakGraph(N_pixels, device):
     return fg
 
 
-def createSwimmingPoolGraph(N_pixels, device):
+def createSwimmingPoolGraph(N_pixels):
 
     fg = filtergraph.FilterGraph(recordTimings=True)
 
-    led_out = devices.LEDOutput(device)
+    led_out = devices.LEDOutput()
     fg.addEffectNode(led_out)
 
     color = colors.StaticRGBColor(N_pixels, 55.0, 150.0, 236.0)
@@ -206,10 +206,10 @@ def createSwimmingPoolGraph(N_pixels, device):
     return fg
 
 
-def createDefenceGraph(N_pixels, device):
+def createDefenceGraph(N_pixels):
     fg = filtergraph.FilterGraph(recordTimings=True)
 
-    led_out = devices.LEDOutput(device)
+    led_out = devices.LEDOutput()
     fg.addEffectNode(led_out)
 
     Defence = generative.DefenceMode(N_pixels)
@@ -219,10 +219,10 @@ def createDefenceGraph(N_pixels, device):
     return fg
 
 
-def createKeyboardGraph(N_pixels, device):
+def createKeyboardGraph(N_pixels):
     fg = filtergraph.FilterGraph(recordTimings=True)
 
-    led_out = devices.LEDOutput(device)
+    led_out = devices.LEDOutput()
     fg.addEffectNode(led_out)
 
     PKeyboard = generative.MidiKeyboard(N_pixels)
@@ -232,10 +232,10 @@ def createKeyboardGraph(N_pixels, device):
     return fg
 
 
-def createKeyboardSpringGraph(N_pixels, device):
+def createKeyboardSpringGraph(N_pixels):
     fg = filtergraph.FilterGraph(recordTimings=True)
 
-    led_out = devices.LEDOutput(device)
+    led_out = devices.LEDOutput()
     fg.addEffectNode(led_out)
 
     PKeyboard = generative.MidiKeyboard(N_pixels)
@@ -255,10 +255,10 @@ def createKeyboardSpringGraph(N_pixels, device):
     return fg
 
 
-def createProxyServerGraph(N_pixels, device):
+def createProxyServerGraph(N_pixels):
     fg = filtergraph.FilterGraph(recordTimings=True)
 
-    led_out = devices.LEDOutput(device)
+    led_out = devices.LEDOutput()
     fg.addEffectNode(led_out)
 
     candyIn = input.CandyServer(N_pixels)
@@ -268,10 +268,10 @@ def createProxyServerGraph(N_pixels, device):
     return fg
 
 
-def createBreathingGraph(N_pixels, device):
+def createBreathingGraph(N_pixels):
     fg = filtergraph.FilterGraph(recordTimings=True)
 
-    led_out = devices.LEDOutput(device)
+    led_out = devices.LEDOutput()
     fg.addEffectNode(led_out)
 
     Breathing = generative.Breathing(N_pixels)
@@ -281,10 +281,10 @@ def createBreathingGraph(N_pixels, device):
     return fg
 
 
-def createHeartbeatGraph(N_pixels, device):
+def createHeartbeatGraph(N_pixels):
     fg = filtergraph.FilterGraph(recordTimings=True)
 
-    led_out = devices.LEDOutput(device)
+    led_out = devices.LEDOutput()
     fg.addEffectNode(led_out)
 
     Heartbeat = generative.Heartbeat(N_pixels)
@@ -294,10 +294,10 @@ def createHeartbeatGraph(N_pixels, device):
     return fg
 
 
-def createFallingStarsGraph(N_pixels, device):
+def createFallingStarsGraph(N_pixels):
     fg = filtergraph.FilterGraph(recordTimings=True)
 
-    led_out = devices.LEDOutput(device)
+    led_out = devices.LEDOutput()
     fg.addEffectNode(led_out)
 
     FallingStars = generative.FallingStars(N_pixels)
@@ -307,10 +307,10 @@ def createFallingStarsGraph(N_pixels, device):
     return fg
 
 
-def createPendulumGraph(N_pixels, device):
+def createPendulumGraph(N_pixels):
     fg = filtergraph.FilterGraph(recordTimings=True)
 
-    led_out = devices.LEDOutput(device)
+    led_out = devices.LEDOutput()
     fg.addEffectNode(led_out)
 
     Pendulum = generative.Pendulum(N_pixels)
@@ -320,10 +320,10 @@ def createPendulumGraph(N_pixels, device):
     return fg
 
 
-def createRPendulumGraph(N_pixels, device):
+def createRPendulumGraph(N_pixels):
     fg = filtergraph.FilterGraph(recordTimings=True)
 
-    led_out = devices.LEDOutput(device)
+    led_out = devices.LEDOutput()
     fg.addEffectNode(led_out)
 
     RPendulum = generative.RandomPendulums(N_pixels)
@@ -333,10 +333,10 @@ def createRPendulumGraph(N_pixels, device):
     return fg
 
 
-def createTestBlobGraph(N_pixels, device):
+def createTestBlobGraph(N_pixels):
     fg = filtergraph.FilterGraph(recordTimings=True)
 
-    led_out = devices.LEDOutput(device)
+    led_out = devices.LEDOutput()
     fg.addEffectNode(led_out)
 
     TestBlob = generative.StaticBlob(N_pixels)
@@ -346,14 +346,14 @@ def createTestBlobGraph(N_pixels, device):
     return fg
 
 
-def createBonfireGraph(N_pixels, device):
+def createBonfireGraph(N_pixels):
 
     fg = filtergraph.FilterGraph(recordTimings=True)
 
     audio_in = audio.AudioInput(num_channels=2)
     fg.addEffectNode(audio_in)
 
-    led_out = devices.LEDOutput(device)
+    led_out = devices.LEDOutput()
     fg.addEffectNode(led_out)
 
     bonfire = audioreactive.Bonfire(N_pixels, fs=audio_in.getSampleRate())
@@ -369,10 +369,10 @@ def createBonfireGraph(N_pixels, device):
     return fg
 
 
-def createGenerateWavesGraph(N_pixels, device):
+def createGenerateWavesGraph(N_pixels):
     fg = filtergraph.FilterGraph(recordTimings=True)
 
-    led_out = devices.LEDOutput(device)
+    led_out = devices.LEDOutput()
     fg.addEffectNode(led_out)
 
     GenerateWaves = generative.GenerateWaves(N_pixels, wavemode='square')

--- a/audioled/project.py
+++ b/audioled/project.py
@@ -5,10 +5,30 @@ from audioled.filtergraph import (FilterGraph, Updateable)
 
 class Project(Updateable):
 
-    def __init__(self):
+    def __init__(self, device=None):
         self.slots = [None for i in range(127)]
         self.activeSlotId = 0
+        self._device = device
 
+    def __cleanState__(self, stateDict):
+        """
+        Cleans given state dictionary from state objects beginning with _
+        """
+        for k in list(stateDict.keys()):
+            if k.startswith('_'):
+                stateDict.pop(k)
+        return stateDict
+
+    def __getstate__(self):
+        """
+        Default implementation of __getstate__ that deletes buffer, call __cleanState__ when overloading
+        """
+        state = self.__dict__.copy()
+        self.__cleanState__(state)
+        return state
+
+    def setDevice(self, device):
+        self._device = device
 
     def update(self, dt, event_loop=asyncio.get_event_loop()):
         """Update active FilterGraph
@@ -22,8 +42,11 @@ class Project(Updateable):
     def process(self):
         """Process active FilterGraph
         """
-        if self.getSlot(self.activeSlotId) is not None:
-            self.getSlot(self.activeSlotId).process()
+        activeFilterGraph = self.getSlot(self.activeSlotId)
+        if activeFilterGraph is not None:
+            activeFilterGraph.process()
+            if self._device is not None and activeFilterGraph.getLEDOutput() is not None:
+                self._device.show(activeFilterGraph.getLEDOutput()._outputBuffer[0])
 
     def setFiltergraphForSlot(self, slotId, filterGraph):
         print("Set {} for slot {}".format(filterGraph, slotId))

--- a/filtergraphDemo.py
+++ b/filtergraphDemo.py
@@ -32,10 +32,10 @@ testblobConf = 'testblob'
 bonfireConf = 'bonfire'
 generatewavesConf = 'generatewaves'
 configChoices = [
-    movingLightConf, spectrumConf, vu_peakConf, movingLightsConf, swimmingConf, defenceConf, proxyConf,
-    fallingConf, breathingConf, heartbeatConf, pendulumConf, rpendulumConf, keyboardConf, keyboardSpringConf,
-    testblobConf, bonfireConf, generatewavesConf
-    ]
+    movingLightConf, spectrumConf, vu_peakConf, movingLightsConf, swimmingConf, defenceConf, proxyConf, fallingConf,
+    breathingConf, heartbeatConf, pendulumConf, rpendulumConf, keyboardConf, keyboardSpringConf, testblobConf,
+    bonfireConf, generatewavesConf
+]
 
 deviceRasp = 'RaspberryPi'
 deviceCandy = 'FadeCandy'
@@ -62,12 +62,7 @@ parser.add_argument(
     help='config to use, default is rolling through all configs')
 parser.add_argument('-s', '--save_config', dest='save_config', type=bool, default=False, help='Save config to config/')
 parser.add_argument(
-    '-A',
-    '--audio_device_index',
-    dest='audio_device_index',
-    type=int,
-    default=None,
-    help='Audio device index to use')
+    '-A', '--audio_device_index', dest='audio_device_index', type=int, default=None, help='Audio device index to use')
 args = parser.parse_args()
 
 num_pixels = args.num_pixels
@@ -88,41 +83,42 @@ config = args.config
 print("The following audio devices are available:")
 audio.print_audio_devices()
 
-def createFilterGraph(config, num_pixels, device):
+
+def createFilterGraph(config, num_pixels):
     if config == movingLightConf:
-        return configs.createMovingLightGraph(num_pixels, device)
+        return configs.createMovingLightGraph(num_pixels)
     elif config == movingLightsConf:
-        return configs.createMovingLightsGraph(num_pixels, device)
+        return configs.createMovingLightsGraph(num_pixels)
     elif config == spectrumConf:
-        return configs.createSpectrumGraph(num_pixels, device)
+        return configs.createSpectrumGraph(num_pixels)
     elif config == vu_peakConf:
-        return configs.createVUPeakGraph(num_pixels, device)
+        return configs.createVUPeakGraph(num_pixels)
     elif config == swimmingConf:
-        return configs.createSwimmingPoolGraph(num_pixels, device)
+        return configs.createSwimmingPoolGraph(num_pixels)
     elif config == defenceConf:
-        return configs.createDefenceGraph(num_pixels, device)
+        return configs.createDefenceGraph(num_pixels)
     elif config == keyboardConf:
-        return configs.createKeyboardGraph(num_pixels, device)
+        return configs.createKeyboardGraph(num_pixels)
     elif config == keyboardSpringConf:
-        return configs.createKeyboardSpringGraph(num_pixels, device)
+        return configs.createKeyboardSpringGraph(num_pixels)
     elif config == proxyConf:
-        return configs.createProxyServerGraph(num_pixels, device)
+        return configs.createProxyServerGraph(num_pixels)
     elif config == fallingConf:
-        return configs.createFallingStarsGraph(num_pixels, device)
+        return configs.createFallingStarsGraph(num_pixels)
     elif config == breathingConf:
-        return configs.createBreathingGraph(num_pixels, device)
+        return configs.createBreathingGraph(num_pixels)
     elif config == heartbeatConf:
-        return configs.createHeartbeatGraph(num_pixels, device)
+        return configs.createHeartbeatGraph(num_pixels)
     elif config == pendulumConf:
-        return configs.createPendulumGraph(num_pixels, device)
+        return configs.createPendulumGraph(num_pixels)
     elif config == rpendulumConf:
-        return configs.createRPendulumGraph(num_pixels, device)
+        return configs.createRPendulumGraph(num_pixels)
     elif config == testblobConf:
-        return configs.createTestBlobGraph(num_pixels, device)
+        return configs.createTestBlobGraph(num_pixels)
     elif config == bonfireConf:
-        return configs.createBonfireGraph(num_pixels, device)
+        return configs.createBonfireGraph(num_pixels)
     elif config == generatewavesConf:
-        return configs.createGenerateWavesGraph(num_pixels, device)
+        return configs.createGenerateWavesGraph(num_pixels)
     else:
         raise NotImplementedError("Config not implemented")
 
@@ -157,9 +153,9 @@ config_idx = 0
 last_switch_time = current_time
 cur_graph = None
 if args.config == '':
-    cur_graph = createFilterGraph(configChoices[config_idx], num_pixels, device)
+    cur_graph = createFilterGraph(configChoices[config_idx], num_pixels)
 else:
-    cur_graph = createFilterGraph(args.config, num_pixels, device)
+    cur_graph = createFilterGraph(args.config, num_pixels)
     saveAndLoad(args.config, cur_graph)
 
 while True:
@@ -170,7 +166,7 @@ while True:
         # switch configuration
         print('---switching configuration---')
         config_idx = (config_idx) % len(configChoices)
-        cur_graph = createFilterGraph(configChoices[config_idx], num_pixels, device)
+        cur_graph = createFilterGraph(configChoices[config_idx], num_pixels)
         cur_graph = saveAndLoad(configChoices[config_idx], cur_graph)
         config_idx = config_idx + 1
         last_switch_time = current_time
@@ -178,6 +174,8 @@ while True:
     cur_graph.update(dt)
     updateTiming.update(timer() - current_time)
     cur_graph.process()
+    if cur_graph.getLEDOutput() is not None:
+        device.show(cur_graph.getLEDOutput()._outputBuffer[0])
     if count == 100:
         cur_graph.printProcessTimings()
         print(updateTiming.__dict__)

--- a/server.py
+++ b/server.py
@@ -13,7 +13,7 @@ from timeit import default_timer as timer
 
 import jsonpickle
 import numpy as np
-from flask import Flask, abort, jsonify, request, send_from_directory, redirect, url_for
+from flask import Flask, abort, jsonify, request, send_from_directory, redirect
 from werkzeug.serving import is_running_from_reloader
 
 from audioled import audio, configs, devices, effects, filtergraph, project
@@ -248,8 +248,6 @@ def create_app():
             result[error.node.uid] = error.message
         return json.dumps(result)
 
-
-    
     @app.route('/project/activeSlot', methods=['POST'])
     def project_activeSlot_post():
         global proj
@@ -413,8 +411,6 @@ if __name__ == '__main__':
     elif args.device == deviceCandy:
         device = devices.FadeCandy(args.device_candy_server)
 
-    devices.LEDOutput.overrideDevice = device
-
     # Initialize Audio device
     if args.audio_device_index is not None:
         audio.AudioInput.overrideDeviceIndex = args.audio_device_index
@@ -430,15 +426,15 @@ if __name__ == '__main__':
     audio.print_audio_devices()
 
     # Initialize project
-    proj = project.Project()
+    proj = project.Project(device)
 
     # Initialize filtergraph
     # fg = configs.createSpectrumGraph(num_pixels, device)
     # fg = configs.createMovingLightGraph(num_pixels, device)
     # fg = configs.createMovingLightsGraph(num_pixels, device)
     # fg = configs.createVUPeakGraph(num_pixels, device)
-    initial = configs.createSwimmingPoolGraph(num_pixels, device)
-    second = configs.createDefenceGraph(num_pixels, device)
+    initial = configs.createSwimmingPoolGraph(num_pixels)
+    second = configs.createDefenceGraph(num_pixels)
     # fg = configs.createKeyboardGraph(num_pixels, device)
 
     proj.setFiltergraphForSlot(12, initial)


### PR DESCRIPTION
Since LED output configuration can be different for every setup, storing the output device in the LEDOutput effect can lead to problems and required a hack to override the output device.
This hack didn't always work (see #68)
The configuration of the output device is now part of the application.

Fixes #68.